### PR TITLE
Fixed min and max coordinates in lammps output

### DIFF
--- a/src/output/out_lammps_data.f90
+++ b/src/output/out_lammps_data.f90
@@ -340,13 +340,13 @@ ENDIF
 !
 !Write supercell data
 IF( VECLENGTH(K(1,:)) > 1.d-12 ) THEN
-  WRITE(ofu,160) zero, K(1,1), '  xlo xhi'
+  WRITE(ofu,160) MIN(K(1,1), zero), MAX(K(1,1), zero), '  xlo xhi'
 ENDIF
 IF( VECLENGTH(K(2,:)) > 1.d-12 ) THEN
-  WRITE(ofu,160) zero, K(2,2), '  ylo yhi'
+  WRITE(ofu,160) MIN(K(2,2), zero), MAX(K(2,2), zero), '  ylo yhi'
 ENDIF
 IF( VECLENGTH(K(3,:)) > 1.d-12 ) THEN
-  WRITE(ofu,160) zero, K(3,3), '  zlo zhi'
+  WRITE(ofu,160) MIN(K(3,3), zero), MAX(K(3,3), zero), '  zlo zhi'
 ENDIF
 !
 !LAMMPS requires that skew parameters are less than half the box


### PR DESCRIPTION
The lammps file output is incorrect if the whole system has been rotated > 90 degrees, since the minimum coordinate becomes larger than the maximum coordinate.

For example the following generates an invalid lammps output file
```bash
atomsk --create bcc 3.3026 Ta -rotate Y 180 tantalum.lmp lammps
```

This PR fixes the aforementioned bug.

Contact info:
Eerik Voimanen
eerik.voimanen@tuni.fi
Research assistant
Tampere University